### PR TITLE
Updated updated

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
-import { v4 as uuidv4 } from "uuid";
-import { Canister, Err, ic, nat, nat64, Ok, Opt, Principal, query, Record, Result, StableBTreeMap, text, update, Vec, Void } from 'azle';
+// index.ts
+import { v4 as uuidv4 } from 'uuid';
+import { Canister, ic, Opt, Principal, query, Record, StableBTreeMap, text, update, Vec } from 'azle';
 import { License, LicenseId, LicensePayload } from './types';
 
 let licenses = StableBTreeMap<LicenseId, License>(0);
 
 export default Canister({
-
-    // Get All License
+    // Get All Licenses
     getLicenses: query([], Vec(License), () => {
         return licenses.values();
     }),
@@ -17,18 +17,17 @@ export default Canister({
     }),
 
     // Create License
-    createLicense: update([Principal, LicensePayload], License, (principal, payload) => {
+    createLicense: update([Principal, LicensePayload], Opt(License), (principal, payload) => {
         const newLicense: License = {
-            id: uuidv4(),
+            licenseId: uuidv4(), // Renamed to licenseId for consistency
             name: payload.name,
             type: payload.type,
             expired: payload.expired,
             principal: principal,
             createdAt: ic.time(),
-          };
+        };
 
-          licenses.insert(newLicense.id, newLicense);
-          return newLicense;
+        licenses.insert(newLicense.licenseId, newLicense);
+        return newLicense;
     }),
 });
-


### PR DESCRIPTION
## Changes Made in Canister

### `types.ts`
- Renamed `id` field to `licenseId` in the `License` record for clarity.
- Updated the associated types accordingly.

### `index.ts`
- Refactored the `createLicense` update function to use the updated `License` record structure.
- Improved code readability and consistency.

These changes enhance the clarity of the codebase and ensure a more consistent naming convention for the `License` record identifier.

Please review the modifications and merge at your earliest convenience. If you have any questions or need further adjustments, feel free to discuss.
